### PR TITLE
Updated Vundle Syntax

### DIFF
--- a/web/static/js/app.jsx
+++ b/web/static/js/app.jsx
@@ -478,9 +478,9 @@ var VundleInstructions = React.createClass({
 
     return <div>
       <p>Place this in your <code>.vimrc:</code></p>
-      <pre>Bundle '{vundleUri}'</pre>
+      <pre>Plugin '{vundleUri}'</pre>
       <p>&hellip; then run the following in Vim:</p>
-      <pre>:source %<br/>:BundleInstall</pre>
+      <pre>:source %<br/>:PluginInstall</pre>
       {/* Hack to get triple-click in Chrome to not over-select. */}
       <div>{'\u00a0' /* &nbsp; */}</div>
     </div>;


### PR DESCRIPTION
Vundle recently changed all of it's references of `Bundle` to `Plugin`. This PR changes the instructions for installing a plugin from `Bundle 'package_name'` to `Plugin 'package_name'`

People already using Vundle should know which syntax they're using, however people newer to Vim who follow the call to action to install Vundle, would be using the new syntax.

In the [Vundle Quick Start](https://github.com/gmarik/Vundle.vim#quick-start) you can see the adjusted syntax.
