### PR TITLE
Show plugin name in document title

### DIFF
--- a/web/static/js/app.jsx
+++ b/web/static/js/app.jsx
@@ -933,8 +933,24 @@ var PluginPage = React.createClass({
     return {};
   },
 
+  updateTitle: function() {
+    if (!this._previousTitle) {
+      this._previousTitle = document.title;
+    }
+    if (this.state.name) {
+      document.title = this.state.name + " - Vim Awesome";
+    }
+  },
+
+  resetTitle: function() {
+    if (this._previousTitle) {
+      document.title = this._previousTitle;
+    }
+  },
+
   componentDidMount: function() {
     this.fetchPlugin();
+    this.updateTitle();
     window.addEventListener("keydown", this.onWindowKeyDown, false);
 
     this.tagXhrQueue = $.Deferred();
@@ -942,7 +958,12 @@ var PluginPage = React.createClass({
   },
 
   componentWillUnmount: function() {
+    this.resetTitle();
     window.removeEventListener("keydown", this.onWindowKeyDown, false);
+  },
+
+  componentDidUpdate: function() {
+    this.updateTitle();
   },
 
   fetchPlugin: function() {


### PR DESCRIPTION
I think this is the most efficient way, so that the name only get's set when we fetch the plugin, and only changed back when the page is updated. Which, since it's React.js, shouldn't happen unless we move to a new page. 
