### PR TITLE
Only run travis tests on the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ install:
     - npm install
 script: 
     - make test
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
This change prevents travis from running builds on branches other than
`master`, however builds for pull requests are not affected. This
ensures the following:

- Branches that are not ready for review are not tested. e.g. if a
  work-in-progress commit is pushed to `my-refactor-branch`, tests will
  not be run. Once this branch is ready for review, and a pull request
  is opened, travis will run a build.

- A pull request's tests will not get stuck behind its own branch's
  builds.

- Builds for `master` are still enabled to ensure that build status for
  `master` is always known (and, ideally, always passing).