### PR TITLE
Only install tox during travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
     - "2.7"
 install:
-    - pip install -r requirements.txt
+    - pip install tox
     - nvm install 4.0 && nvm 4.0
     - npm install
 script: 


### PR DESCRIPTION
`tox` handles dependencies for Python tests, so installing from
`requirements.txt` is no longer necessary.