### PR TITLE
Split query parsing out into a util

### DIFF
--- a/web/static/js/Sidebar.jsx
+++ b/web/static/js/Sidebar.jsx
@@ -1,0 +1,78 @@
+/** @jsx React.DOM */
+
+"use strict";
+
+var $ = require("jquery");
+var _ = require("underscore");
+var React = require("react");
+var transitionTo = require("react-nested-router").transitionTo;
+
+var SidebarCategory = require("./SidebarCategory.jsx");
+var utils = require("./utils.js");
+var fetchAllCategories = require("./fetchAllCategories.js");
+
+
+var Sidebar = React.createClass({
+  getInitialState: function() {
+    return {
+      categories: []
+    };
+  },
+
+  componentDidMount: function() {
+    fetchAllCategories(function(categories) {
+      if (this.isMounted()) {
+        this.setState({categories: categories});
+      }
+    }.bind(this));
+
+    // This event is triggered by Bootstrap's collapse widget (which creates the
+    // accordion) when a category is expanded.
+    $(this.refs.categories.getDOMNode()).on('show', this.onCategoryShow);
+  },
+
+  onCategoryShow: function(e) {
+    var category = $(e.target).data('category');
+    transitionTo("plugin-list", null, {"q": "cat:" + category});
+  },
+
+  render: function() {
+    var selectedTags = [];
+    // Use _.get when it's ready (or when we switch to lodash)
+    if (this.props.query && this.props.query.q) {
+      selectedTags = utils.getQueriesWithPrefix(this.props.query.q, 'tag');
+    }
+
+    var categories = _.reject(this.state.categories, {id: "uncategorized"});
+
+    return <div className="sidebar">
+      <h1 className="title">
+        <a href="/">
+          <span className="vim">Vim</span>Awesome
+        </a>
+      </h1>
+      <div className="tac">
+        <div className="subtitle">
+          <div className="line1">Awesome Vim plugins</div>
+          <div className="from">from</div>
+          <div className="line2">across the Universe</div>
+          <div className="from-line"></div>
+        </div>
+      </div>
+      <ul ref="categories" className="categories">{
+        categories.map(function(category) {
+          return <SidebarCategory
+            key={category.id}
+            category={category}
+            selectedTags={selectedTags}
+          />
+        })
+      }</ul>
+      <a href="/submit" className="submit-plugin">
+        <i className="icon-plus"></i>Submit plugin
+      </a>
+    </div>;
+  }
+});
+
+module.exports = Sidebar;

--- a/web/static/js/__tests__/Sidebar-test.jsx
+++ b/web/static/js/__tests__/Sidebar-test.jsx
@@ -1,0 +1,18 @@
+/** @jsx React.DOM */
+
+"use strict"
+
+var React = require('react');
+
+var Sidebar = require('../Sidebar.jsx');
+
+describe('Sidebar', function() {
+  it('renders without throwing', function() {
+    var query = 'cat:code-display tag:css';
+    var container = document.createElement('div');
+    React.renderComponent(
+      <Sidebar query={query} />,
+      container
+    );
+  });
+});

--- a/web/static/js/__tests__/utils-test.js
+++ b/web/static/js/__tests__/utils-test.js
@@ -1,0 +1,32 @@
+/** @jsx React.DOM */
+
+"use strict"
+
+var utils = require('../utils.js');
+
+describe('getQueriesWithPrefix', function() {
+  it('can handle an empty string', function() {
+    var queryObj = utils.getQueriesWithPrefix('', 'foo');
+    expect(queryObj).toEqual([]);
+  });
+  it('can parse tags', function() {
+    var queryObj = utils.getQueriesWithPrefix('tag:foo tag:bar', 'tag');
+    expect(queryObj).toEqual(['foo', 'bar']);
+  });
+  it('ignores other types', function() {
+    var queryObj = utils.getQueriesWithPrefix('cat:foo tag:bar', 'tag');
+    expect(queryObj).toEqual(['bar']);
+  });
+  it('ignores generic queries', function() {
+    var queryObj = utils.getQueriesWithPrefix('foo tag:bar', 'tag');
+    expect(queryObj).toEqual(['bar']);
+  });
+  it('does not include keys that lack values', function() {
+    var queryObj = utils.getQueriesWithPrefix('tag', 'tag');
+    expect(queryObj).toEqual([]);
+  });
+  it('uses `:` to delineate key:value', function() {
+    var queryObj = utils.getQueriesWithPrefix('tag>biz tag:bar', 'tag');
+    expect(queryObj).toEqual(['bar']);
+  });
+});

--- a/web/static/js/app.jsx
+++ b/web/static/js/app.jsx
@@ -30,10 +30,9 @@ var AboutPage = require("./AboutPage.jsx");
 var NotFound = require("./NotFound.jsx");
 var Footer = require("./Footer.jsx");
 var Plugin = require("./Plugin.jsx");
-var SidebarCategory = require("./SidebarCategory.jsx");
 var Spinner = require("./Spinner.jsx");
+var Sidebar = require("./Sidebar.jsx");
 
-var utils = require("./utils.js");
 
 var fetchAllCategories = require("./fetchAllCategories.js");
 
@@ -88,69 +87,6 @@ var scrollToNode = function(domNode, context) {
     window.scrollTo(0, Math.max(0, elementTop - context));
   }
 };
-
-var Sidebar = React.createClass({
-  getInitialState: function() {
-    return {
-      categories: []
-    };
-  },
-
-  componentDidMount: function() {
-    fetchAllCategories(function(categories) {
-      if (this.isMounted()) {
-        this.setState({categories: categories});
-      }
-    }.bind(this));
-
-    // This event is triggered by Bootstrap's collapse widget (which creates the
-    // accordion) when a category is expanded.
-    $(this.refs.categories.getDOMNode()).on('show', this.onCategoryShow);
-  },
-
-  onCategoryShow: function(e) {
-    var category = $(e.target).data('category');
-    transitionTo("plugin-list", null, {"q": "cat:" + category});
-  },
-
-  render: function() {
-    var selectedTags = [];
-    // Use _.get when it's ready (or when we switch to lodash)
-    if (this.props.query && this.props.query.q) {
-      selectedTags = utils.getQueriesWithPrefix(this.props.query.q, 'tag');
-    }
-
-    var categories = _.reject(this.state.categories, {id: "uncategorized"});
-
-    return <div className="sidebar">
-      <h1 className="title">
-        <a href="/">
-          <span className="vim">Vim</span>Awesome
-        </a>
-      </h1>
-      <div className="tac">
-        <div className="subtitle">
-          <div className="line1">Awesome Vim plugins</div>
-          <div className="from">from</div>
-          <div className="line2">across the Universe</div>
-          <div className="from-line"></div>
-        </div>
-      </div>
-      <ul ref="categories" className="categories">{
-        categories.map(function(category) {
-          return <SidebarCategory
-            key={category.id}
-            category={category}
-            selectedTags={selectedTags}
-          />
-        })
-      }</ul>
-      <a href="/submit" className="submit-plugin">
-        <i className="icon-plus"></i>Submit plugin
-      </a>
-    </div>;
-  }
-});
 
 var SearchBox = React.createClass({
   componentDidMount: function() {

--- a/web/static/js/app.jsx
+++ b/web/static/js/app.jsx
@@ -33,6 +33,8 @@ var Plugin = require("./Plugin.jsx");
 var SidebarCategory = require("./SidebarCategory.jsx");
 var Spinner = require("./Spinner.jsx");
 
+var utils = require("./utils.js");
+
 var fetchAllCategories = require("./fetchAllCategories.js");
 
 // TODO(david): We might want to split up this file more.
@@ -111,27 +113,11 @@ var Sidebar = React.createClass({
     transitionTo("plugin-list", null, {"q": "cat:" + category});
   },
 
-  tagsFromQuery: function(queryString) {
-    function isTag(query) {
-      return query && startsWith(query, "tag:");
-    }
-
-    function getTag(query) {
-      return query.split(":")[1];
-    }
-
-    var queries = queryString.split(" ");
-    return _.chain(queries)
-            .filter(isTag)
-            .map(getTag)
-            .value();
-  },
-
   render: function() {
     var selectedTags = [];
     // Use _.get when it's ready (or when we switch to lodash)
     if (this.props.query && this.props.query.q) {
-      selectedTags = this.tagsFromQuery(this.props.query.q);
+      selectedTags = utils.getQueriesWithPrefix(this.props.query.q, 'tag');
     }
 
     var categories = _.reject(this.state.categories, {id: "uncategorized"});

--- a/web/static/js/utils.js
+++ b/web/static/js/utils.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var _ = require("underscore");
+
+// Given a search string, find the values that have a given prefix.
+function getQueriesWithPrefix(queryString, prefix) {
+  function hasPrefix(query) {
+    var parts = query.split(":");
+    return parts[0] === prefix && parts[1];
+  }
+
+  function getValue(query) {
+    return query.split(":")[1];
+  }
+
+  var queries = queryString.split(" ");
+  return _.chain(queries)
+          .filter(hasPrefix)
+          .map(getValue)
+          .value();
+}
+
+module.exports = {
+  getQueriesWithPrefix: getQueriesWithPrefix
+}


### PR DESCRIPTION
In an attempt to make things more readable and testable. Splits Sidebar and `getQueriesWithPrefix` out into their own files so that they can be tested.