### PR TITLE
Upgrade RethinkDB (fixes #94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ repos on GitHub, it is still a useful source of relative usage data.
 ## Getting set up
 
 <!-- TODO(david): Don't hardcode version here. -->
-1. Install RethinkDB version 1.16.1 from http://rethinkdb.com/docs/install/.
+1. Install RethinkDB version 2.2.0 from http://rethinkdb.com/docs/install/.
   (You may have to dig into the
   [download archives](http://download.rethinkdb.com/).)
 

--- a/db/plugins.py
+++ b/db/plugins.py
@@ -555,12 +555,12 @@ def get_search_index():
 
     # Don't show plugin managers because they're not technically plugins, and
     # also our usage counts for them are not all accurate.
-    query = query.filter(r.all(
-        r.row['slug'] != 'vundle',
-        r.row['slug'] != 'neobundle-vim',
-        r.row['slug'] != 'neobundle-vim-back-to-december',
-        r.row['slug'] != 'pathogen-vim',
-    ))
+    query = query.filter(
+        (r.row['slug'] != 'vundle') &
+        (r.row['slug'] != 'neobundle-vim') &
+        (r.row['slug'] != 'neobundle-vim-back-to-december') &
+        (r.row['slug'] != 'pathogen-vim')
+    )
 
     plugins = map(to_json, query.run(r_conn()))
 

--- a/db/plugins.py
+++ b/db/plugins.py
@@ -555,11 +555,13 @@ def get_search_index():
 
     # Don't show plugin managers because they're not technically plugins, and
     # also our usage counts for them are not all accurate.
+    plugin_manager_slugs = [
+        'vundle',
+        'neobundle-vim',
+        'neobundle-vim-back-to-december',
+        'pathogen-vim']
     query = query.filter(
-        (r.row['slug'] != 'vundle') &
-        (r.row['slug'] != 'neobundle-vim') &
-        (r.row['slug'] != 'neobundle-vim-back-to-december') &
-        (r.row['slug'] != 'pathogen-vim')
+        lambda row: r.expr(plugin_manager_slugs).contains(row['slug']).not_()
     )
 
     plugins = map(to_json, query.run(r_conn()))

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 raven[flask]
-rethinkdb==1.14.0-0
+rethinkdb==2.2.0-0
 Flask==0.9
 requests>=1.2.3,<2.0.0
 lxml>=3.2.1,<4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ python-slugify==0.0.6
 PyYAML==3.11
 raven[flask]==5.12.0
 requests==1.2.3
-rethinkdb==1.14.0-0
+rethinkdb==2.2.0-0
 six==1.10.0               # via html5lib, python-dateutil
 termcolor==1.1.0
 tox==2.3.1


### PR DESCRIPTION
Fixes #94 

To test this, I've loaded each of the web pages and tried all the actions
I could think of. I also ran each of the tasks mentioned in `crontab` with no
problems.

Changelog here: https://github.com/rethinkdb/rethinkdb/releases?before=v1.16.1&after=v2.2.1

Order of operations to deploy
----------------------------

Upgrade the actual database package:

    apt-get install --only-upgrade rethinkdb=2.2.0

Rebuild the index:

    rethinkdb index-rebuild

Deploy this PR:

    make deploy