### PR TITLE
Actually persist user-submitted tags

### DIFF
--- a/web/api/api.py
+++ b/web/api/api.py
@@ -176,6 +176,7 @@ def update_plugin_tags(slug):
         return api_util.api_not_found('No plugin with slug %s' % slug)
 
     db.plugins.update_tags(plugin, data['tags'])
+    r.table('plugins').update(plugin).run(r_conn())
     return api_util.jsonify({
         'tags': plugin['tags']
     })


### PR DESCRIPTION
Fixes #142

I think I figured out what happened.

* Aug. 8, 2016 @andyzg opens PR #52 which moves `update_plugin_tags()` from `web/server.py` to `web/api/api.py`.

* Aug 9, 2014 In [this commit](https://github.com/vim-awesome/vim-awesome/commit/00f90ac6227ed0caa80c0a242a52350b89efc87e), @divad12 moves saving new tags from `db/plugins.py:update_tags()` to `web/server.py:update_plugin_tags()`

* Time passes with #52 still unmerged ...

* Feb 16, 2015 @divad12 notices that #52 is still unmerged but now has conflicts. He rebases himself and merges the changes as a single [commit](https://github.com/vim-awesome/vim-awesome/commit/9247cf3c50bdbe162939ac324be91997870b162a#diff-147901e562054c84aefae45f11a38a39).  He documents his actions in this [comment](https://github.com/vim-awesome/vim-awesome/pull/52#issuecomment-74613181) on #52.

During that rebase, it looks like the saving of tags in `web/server.py:update_plugin_tags()` was accidentally deleted.