### PR TITLE
Always import from root

### DIFF
--- a/web/api/api.py
+++ b/web/api/api.py
@@ -5,7 +5,7 @@ import re
 
 import flask
 from flask import request
-from cache import cache
+from web.cache import cache
 import requests
 import rethinkdb as r
 

--- a/web/server.py
+++ b/web/server.py
@@ -1,7 +1,7 @@
 import logging
 
 import flask
-from cache import cache
+from web.cache import cache
 from raven.contrib.flask import Sentry
 
 import db


### PR DESCRIPTION
Somehow both `vim-awesome` and `vim-awesome/web` are in `sys.path` when we run
the actual application. This made it possible to have these rather funky
imports.