### PR TITLE
Upgrade Flask

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 raven[flask]
 rethinkdb==2.2.0.post6
-Flask==0.9
+Flask
 requests>=2.9.1,<3.0.0
 lxml>=3.2.1,<4.0.0
 html5lib==1.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,9 @@ blinker==1.4              # via raven
 configparser==3.5.0b2
 contextlib2==0.5.1        # via raven
 Flask-Cache==0.12
-Flask==0.9                # via flask-cache, raven
+flask==0.10.1
 html5lib==1.0b1
+itsdangerous==0.24        # via flask
 Jinja2==2.8               # via flask
 lxml==3.5.0
 MarkupSafe==0.23          # via jinja2


### PR DESCRIPTION
Upgrade Flask from 0.9 to 0.10.1 (the latest stable release). Per the
changelog [1] and the upgrading guide [2], there are bug fixes,
improvements, and no breaking changes in these versions.

[1] http://flask.pocoo.org/docs/0.10/changelog/
[2] http://flask.pocoo.org/docs/0.10/upgrading/