### PR TITLE
Begin validating plugin submissions

### DIFF
--- a/web/static/js/SubmitPage.jsx
+++ b/web/static/js/SubmitPage.jsx
@@ -13,8 +13,11 @@ var Tags = require("./Tags.jsx");
 var SubmitPage = React.createClass({
   getInitialState: function() {
     return {
+      name: '',
+      author: '',
       tags: [],
-      category: "uncategorized"
+      category: "uncategorized",
+      submitting: false
     };
   },
 
@@ -26,15 +29,51 @@ var SubmitPage = React.createClass({
     this.setState({category: category});
   },
 
+  nameIsValid: function() {
+    return this.state.name !== '';
+  },
+
+  authorIsValid: function() {
+    return this.state.author !== '';
+  },
+
+  onNameChange: function(e) {
+    return this.setState({name: e.target.value});
+  },
+
+  onAuthorChange: function(e) {
+    return this.setState({author: e.target.value});
+  },
+
+  formIsValid: function() {
+    return _.every([
+        this.nameIsValid(),
+        this.authorIsValid()
+    ]);
+  },
+
+  // TODO(captbaritone): Submit the form via API
+  onSubmit: function() {
+    // Enable validation errors
+    this.setState({submitting: true});
+
+    // Should the for actually submit?
+    return this.formIsValid();
+  },
+
   render: function() {
+    var submitting = this.state.submitting;
     return <div className="submit-page">
       <h1>Submit plugin</h1>
-      <form className="form-horizontal" action="/api/submit" method="POST">
+      <form className="form-horizontal" action="/api/submit"
+          method="POST" onSubmit={this.onSubmit} >
         <div className="control-group">
           <label className="control-label" htmlFor="name-input">Name</label>
           <div className="controls">
             <input type="text" name="name" id="name-input"
-                placeholder="e.g. Fugitive" />
+                className={submitting && !this.nameIsValid() ? 'error' : ''}
+                placeholder="e.g. Fugitive" value={this.state.name}
+                onChange={this.onNameChange} />
           </div>
         </div>
         <div className="control-group">
@@ -43,7 +82,9 @@ var SubmitPage = React.createClass({
           </label>
           <div className="controls">
             <input type="text" name="author" id="author-input"
-                placeholder="e.g. Tim Pope" />
+                className={submitting && !this.authorIsValid() ? 'error' : ''}
+                placeholder="e.g. Tim Pope" value={this.state.author}
+                onChange={this.onAuthorChange} />
           </div>
         </div>
         <div className="control-group">

--- a/web/static/sass/screen.scss
+++ b/web/static/sass/screen.scss
@@ -1502,6 +1502,11 @@ $long-desc-bg: #FBFBFB;
       border-bottom: 2px solid mix($content-1, $bg-light-1, 50%);
     }
 
+    &.error {
+      @include transition(all 0.1s ease-out);
+      background-color: $errorBackground;
+    }
+
     @include placeholder {
       font-weight: 300;
       font-size: 15px;


### PR DESCRIPTION
The "Name" and "Author" fields are theoretically required, but up to this point we have made no effort to actually enforce that requirement. This will give the user a blocking validation error (in the form of the invalid inputs changing color) if they try to submit the form with either of these fields empty.

This also sets us up for future validation of the two URL fields.

Screenshot for design review (@divad12):

<img width="1223" alt="screen shot 2016-05-07 at 6 29 01 pm" src="https://cloud.githubusercontent.com/assets/162735/15095569/9f85a24c-1481-11e6-8c22-12c61e3012df.png">