### PR TITLE
Require a repo name in GitHub submissions

### DIFF
--- a/tools/review_submitted_plugins.py
+++ b/tools/review_submitted_plugins.py
@@ -20,7 +20,7 @@ import util
 r_conn = db.util.r_conn
 
 
-_GITHUB_LINK_REGEX = re.compile(r'github.com/(.*?)/([^/?#]*)')
+_GITHUB_LINK_REGEX = re.compile(r'github.com/(.*?)/([^/?#]+)')
 
 
 # From http://stackoverflow.com/a/3041990


### PR DESCRIPTION
Previously `http://github.com/foo/` would pass the test. Now you must also have
a repo name: `http://github.com/foo/bar`.