### PR TITLE
Update nopep8 instructions to NOQA

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,4 +1,4 @@
-import categories  # nopep8
-import plugins  # nopep8
-import submitted_plugins  # nopep8
-import tags  # nopep8
+import categories  # NOQA: F401
+import plugins  # NOQA: F401
+import submitted_plugins  # NOQA: F401
+import tags  # NOQA: F401


### PR DESCRIPTION
`flake8` seems to have dropped support for `# nopep8` in the 3.x
versions (confirmed by testing with latest and `<3`). This causes our
style checking tests to fail.

Replace these with `# NOQA` and pin them to the specific error we care
about here (F401 unused import).