### PR TITLE
Switch from bundle to bundler in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
-gem "bundle"
+gem "bundler"
 gem "compass", "~> 0.12.2"
 gem "bootstrap-sass", "~> 2.3.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,6 @@ GEM
   specs:
     bootstrap-sass (2.3.1.2)
       sass (~> 3.2)
-    bundle (0.0.1)
-      bundler
     chunky_png (1.2.8)
     compass (0.12.2)
       chunky_png (~> 1.2)
@@ -18,5 +16,5 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap-sass (~> 2.3.1.2)
-  bundle
+  bundler
   compass (~> 0.12.2)


### PR DESCRIPTION
Whilst working on [Libraries.io](https://libraries.io) I noticed that this project depends on the [`bundle`](https://github.com/will/bundle) gem rather than [`bundler`](https://github.com/bundler/bundler/), this pull request fixes the typo and updates the Gemfile.lock