### PR TITLE
Make Logrotate config symbolic link absolute

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -75,6 +75,6 @@ echo "Installing crontab"
 ( cd $NEW_CLONE && crontab crontab )
 
 echo "Installing logrotate config"
-sudo ln -sfnv $NEW_CLONE/conf/etc/logrotate.d/vim-awesome-cron /etc/logrotate.d
+sudo ln -sfnv $HOME/$NEW_CLONE/conf/etc/logrotate.d/vim-awesome-cron /etc/logrotate.d
 
 PYTHONPATH=$NEW_CLONE python $NEW_CLONE/tools/notify_deploy.py $DEPLOYER


### PR DESCRIPTION
While looking into #320 I noticed that we do, infact have a logrotate config file checked into the repo. It didn't attempt to rotate the database dumps, but it seemed like a good place to start.

After seeing this line in the deploy script, I went looking for the file in `/etc/logrotate.d/` and couldn't find it. Remembering a past experience where I had been burned by relative symbolic links in the paste, I did some reading, and realized that we were actually creating a symbolic link to:

    /etc/logrotate.d/$NEW_CLONE/conf/etc/logrotate.d/vim-awesome-cron

Obviously, that file does not exist. Making this an absolute link seems to work. I tried it manually, and the file is now accessible as `/etc/logrotate.d/vim-awesome-cron`.

Looking at the server, the most recent archived logs are from August 2014. Looking through the git history around that time, I found the commit which introduced this line to the deploy script: 6fe39e5b81c0253c08a7a2ac7f5582fcdd86feb3.

I'm guessing the script had been manually added to `/etc/logrotate.d/` and this mistake in the deploy script caused it to be replaced by a link to nowhere and thus rotation halted.

Review @divad12, @spicyj or @jonafato 