### PR TITLE
Fix nvm command in TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
     - "2.7"
 install:
     - pip install tox
-    - nvm install 4.0 && nvm 4.0
+    - nvm install 4.0 && nvm use 4.0
     - npm install
 script: 
     - make test


### PR DESCRIPTION
The `nvm 4.0` command returns an error code of 127 and halts the build.
See builds 312 and 313: https://travis-ci.org/vim-awesome/vim-awesome/builds
The command should be `nvm use 4.0`.

The breakage started after TravisCI switched from Precise to Trusty images (this is visible in the build logs).