### PR TITLE
Fix sidebar always visible scroll

### DIFF
--- a/web/static/sass/screen.scss
+++ b/web/static/sass/screen.scss
@@ -114,7 +114,7 @@ code {
   top: 0;
 
   @media #{$large-screen} {
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   @media #{$not-large-screen} {


### PR DESCRIPTION
I think it's better to hide scroll when there is enough vertical space for the sidebar.